### PR TITLE
Addresses #6 by moving state to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.4] 
 ### Fixed
 - Alpine users likely saw 'missing state' errors (Issue #6)
+
+
+## [1.0.3]
+### Added
+- Orb will pull Issue Key from branch (Issue #5), Thanks to [Nick](https://github.com/nickmbailey)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.4] 
+### Fixed
+- Alpine users likely saw 'missing state' errors (Issue #6)

--- a/src/examples/basic_build.yml
+++ b/src/examples/basic_build.yml
@@ -2,7 +2,7 @@ description: Notify jira on single job
 usage:
   version: 2.1
   orbs: 
-    jira: circleci/jira@volatile
+    jira: circleci/jira@x.y.z
 
   workflows:
     build:

--- a/src/examples/full_workflow.yml
+++ b/src/examples/full_workflow.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
 
   orbs:
-    jira: circleci/jira@volatile
+    jira: circleci/jira@x.y.z
 
   workflows:
     build-deploy:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -30,17 +30,21 @@ commands:
         type: enum
         enum: ["production", "staging", "testing", "development", "unmapped"]
         default: "development"
+      state_path:
+        description: Relative or absolute path to a store build state for orb.
+        default: "./circleci-orb-jira.status"
+        type: string
     steps:
       - run:
           name: JIRA - Setting Failure Condition
           command: |
-            echo 'export JIRA_BUILD_STATUS="failed"' >> $BASH_ENV
+            echo 'JIRA_BUILD_STATUS="failed"' > <<parameters.state_path>>
           when: on_fail
 
       - run:
           name: JIRA - Setting Success Condition
           command: |
-            echo 'export JIRA_BUILD_STATUS="successful"' >> $BASH_ENV
+            echo 'JIRA_BUILD_STATUS="successful"' > <<parameters.state_path>>
           when: on_success
 
       - run:
@@ -137,6 +141,7 @@ commands:
             }
 
             generate_json_payload_deployment () {
+              echo "Update Jira with status: ${JIRA_BUILD_STATUS}"
               iso_time=$(date '+%Y-%m-%dT%T%z'| sed -e 's/\([0-9][0-9]\)$/:\1/g')
               echo {} | jq \
               --arg time_str "$(date +%s)" \
@@ -210,4 +215,6 @@ commands:
 
 
             # kick off
+            source <<parameters.state_path>>
             run
+            rm -f <<parameters.state_path>>

--- a/tests/cases/deployment.yml
+++ b/tests/cases/deployment.yml
@@ -8,3 +8,4 @@ jobs:
       - jira/notify:
           job_type: deployment
           environment: non-prod
+          state_path:  /tmp/jira.status

--- a/tests/cases/simple.yml
+++ b/tests/cases/simple.yml
@@ -5,4 +5,5 @@ jobs:
     - image: circleci/node:10
     steps:
       - run: echo "hello"
-      - jira/notify
+      - jira/notify:
+          state_path:  /tmp/jira.status

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -59,7 +59,7 @@ function setup {
   export CIRCLE_COMPARE_URL="https://github.com/CircleCI-Public/jira-connect-orb"
   export CIRCLE_BUILD_URL="https://circleci.com/gh/project/build/23"
   export CIRCLE_BRANCH="master"
-  export JIRA_BUILD_STATUS="successful"
+  echo 'export JIRA_BUILD_STATUS="successful"' >> /tmp/jira.status
   process_config_with tests/cases/simple.yml
 
 
@@ -93,7 +93,7 @@ function setup {
   export CIRCLE_COMPARE_URL="https://github.com/CircleCI-Public/jira-connect-orb"
   export CIRCLE_BUILD_URL="https://circleci.com/gh/project/build/355"
   export CIRCLE_BRANCH="master"
-  export JIRA_BUILD_STATUS="successful"
+  echo 'export JIRA_BUILD_STATUS="successful"' >> /tmp/jira.status
   process_config_with tests/cases/simple.yml
 
 
@@ -140,7 +140,7 @@ function setup {
   export CIRCLE_COMPARE_URL="https://github.com/CircleCI-Public/jira-connect-orb"
   export CIRCLE_BUILD_URL="https://circleci.com/gh/project/build/23"
   export CIRCLE_BRANCH="master"
-  export JIRA_BUILD_STATUS="successful"
+  echo 'export JIRA_BUILD_STATUS="successful"' >> /tmp/jira.status
   process_config_with tests/cases/deployment.yml
 
 


### PR DESCRIPTION
### Checklist



- [x ] All new jobs, commands, executors, parameters have descriptions
- [x ] Examples have been added for any significant new features
- [ x] README has been updated, if necessary

### Motivation, issues
Fix issue #6 to be more portable and not depend on fickle environment tricks.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Save state to a file (parameter defaults to workdir file) that is read by publish job before generating the json payload.
