### PR TITLE
Install jq if not available

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -8,6 +8,9 @@ description: >
   Please see [CircleCI Jira integration docs](https://circleci.com/docs/2.0/jira-plugin/)
 
   Orb source code available here: https://github.com/CircleCI-Public/jira-connect-orb
+  
+orbs:
+  circleci/jq@1.8.0
 
 commands:
   notify:
@@ -35,6 +38,8 @@ commands:
         default: "./circleci-orb-jira.status"
         type: string
     steps:
+      - jq/install
+      
       - run:
           name: JIRA - Setting Failure Condition
           command: |


### PR DESCRIPTION
https://github.com/CircleCI-Public/jira-connect-orb/issues/10

we install jq by default in our images, but other images may not have it. the jq orb already does a check to see if it needs to do anything, so we can just run `jq/install` every time before moving on to the jira logic