### PR TITLE
Expanded regex for issue scanning [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,21 +58,31 @@ jobs:
       - run:
           name: Promote to prod
           command: |
-            PUBLISH_MESSAGE=`circleci orb publish promote circleci/jira@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} patch --token ${CIRCLECI_API_KEY}`
-            echo $PUBLISH_MESSAGE
-            ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
-            echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
-      - run:
-          name: Publish Prod version to PR
-          command: |
-            curl "https://circleci.com/api/v1.1/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}?circle-token=${CIRCLECI_API_KEY}" > build_info.txt
-            PR_NUMBER=`jq -r '.subject' build_info.txt | sed -n 's/Merge pull request #\([0-9]*\) from.*/\1/p'`
+            # this repo uses squash commits with PR in tparens i,e. "blah blah (#21)"
+            PR_NUMBER=`git log -1 --pretty=%B | sed -n 's/.*(#\([0-9]*\)).*/\1/p'`
             echo "PR_NUMBER is ${PR_NUMBER}"
             if [ "$PR_NUMBER" == "" ];then
               echo "No pr found, do nothing"
-              exit 0
+              exit 1
             fi
-            curl -X POST -u cpe-bot:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"*Production* version of orb available for use - \`${ORB_VERSION}\`\"}"
+            SEMVER_INCREMENT=`git log -1 --pretty=%B | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
+            if [ -z ${SEMVER_INCREMENT} ];then
+              echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
+              exit 1
+            elif [ "$SEMVER_INCREMENT" == "skip" ];then
+              echo "SEMVER in commit indicated to skip orb release"
+              echo "export PR_MESSAGE=\"BotComment: Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
+              exit 0
+            else
+              PUBLISH_MESSAGE=`circleci orb publish promote circleci/jira@dev:${PR_NUMBER} ${SEMVER_INCREMENT} --token ${CIRCLECI_API_KEY}`            
+              echo $PUBLISH_MESSAGE
+              ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
+              echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
+            fi
+      - run:
+          name: Publish Prod version to PR
+          command: |
+            curl -X POST -u cpe-bot:${GHI_TOKEN} "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${PR_MESSAGE}\"}"
 
 commands:
   install-bats:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -21,6 +21,10 @@ parameters:
     description: Relative or absolute path to a store build state for orb.
     default: "./circleci-orb-jira.status"
     type: string
+  issue_regexp:
+    description: Override the default project key regexp if your project keys follow a different format. 
+    default: "[A-Z]{2,30}-[0-9]+"
+    type: string
 steps:
   - jq/install
   
@@ -66,7 +70,7 @@ steps:
           -o /tmp/job_info.json \
           https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}
           # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("([A-Z0-9]{2,30}-[0-9]+)")   | .[] ] + [.all_commit_details[].branch | scan("([A-Z]{2,30}-[0-9]+)")   | .[] ]')
+          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("([A-Z]{2,30}-[0-9]+)")   | .[] ]')
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -66,7 +66,7 @@ steps:
           -o /tmp/job_info.json \
           https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}
           # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("([A-Z]{2,30}-[0-9]+)")   | .[] ] + [.all_commit_details[].branch | scan("([A-Z]{2,30}-[0-9]+)")   | .[] ]')
+          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("([A-Z0-9]{2,30}-[0-9]+)")   | .[] ] + [.all_commit_details[].branch | scan("([A-Z]{2,30}-[0-9]+)")   | .[] ]')
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -70,7 +70,7 @@ steps:
           -o /tmp/job_info.json \
           https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}
           # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("([A-Z]{2,30}-[0-9]+)")   | .[] ]')
+          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ]')
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."


### PR DESCRIPTION
User expressed failure matching jira issues that begin with letters+numbers like so: `MG01-115`
The user also provided this suggested regex: `[A-Z0-9]{2,30}-[0-9]`

