### PR TITLE
doc change: explicit about cloud requirements [semver:patch]

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 description: >
-  This Orb reports the status of builds and deployments in CircleCI Projects to your Jira installation.
+  This Orb reports the status of builds and deployments in CircleCI Projects to your Jira Cloud instance.
 
-  Requires that [CircleCI for Jira](https://marketplace.atlassian.com/apps/1215946) be installed in the Jira instance.
+  Requires that [CircleCI for Jira](https://marketplace.atlassian.com/apps/1215946) be installed in the Jira *Cloud* instance.
 
   Please see [CircleCI Jira integration docs](https://circleci.com/docs/2.0/jira-plugin/)
 


### PR DESCRIPTION
This orb uses JWT auth and the Atlassian Connect framework which is cloud only. This is Atlassian policy and nothing we can influence or workaround.

