### PR TITLE
Scan branch value for issue key (Issue #18). [semver:patch]

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -70,7 +70,7 @@ steps:
           -o /tmp/job_info.json \
           https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}
           # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ]')
+          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.branch | scan("(<<parameters.issue_regexp>>)")  | . [] ]')
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Solves Issue #18 by scanning the `branch` field for issue keys.  This will allow
keys to be discovered in API triggered builds.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Added the `branch` field to the `jq` query command that populates the `$ISSUE_KEYS` variable.  This will allow API triggered builds to have JIRA keys detected as long as the JIRA key is part of the branch name.