### PR TITLE
:bug: Use the login field instead the name to avoid profile without name [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # add your orb below, to be used in integration tests (note: a @dev:alpha
 # release must exist.);
 orbs:
-  jira: circleci/jira@dev:alpha
+  jira: circleci/jira@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@9.0
   circleci-cli: circleci/circleci-cli@0.1
 

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -76,7 +76,7 @@ steps:
         verify_api_key () {
           URL="https://circleci.com/api/v2/me"
           fetch $URL /tmp/me.json
-          jq -e '.name' /tmp/me.json
+          jq -e '.login' /tmp/me.json
         }
 
         fetch () {


### PR DESCRIPTION
### Checklist
- [ X] All new jobs, commands, executors, parameters have descriptions
- [ X] Examples have been added for any significant new features
- [ X] README has been updated, if necessary

### Motivation, issues

This commit fix the problem describe in this bug https://github.com/CircleCI-Public/jira-connect-orb/issues/40.

### Description

Change the lookup field `name` for `login`