### PR TITLE
Request API token for API verify step [semver:patch]

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -74,7 +74,7 @@ steps:
         }
 
         verify_api_key () {
-          URL="https://circleci.com/api/v2/me"
+          URL="https://circleci.com/api/v2/me?circle-token=${<<parameters.token_name>>}"
           fetch $URL /tmp/me.json
           jq -e '.name' /tmp/me.json
         }


### PR DESCRIPTION
Patch change to resolve the login verify. 

verify_api_key function now makes request with API key.

Curious when this came out or if this was somehow always like this, will check that out after.