### PR TITLE
[semver:minor] Bump circleci/jq from `2.0` to `2.1`

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -8,7 +8,7 @@ description: >
   Please see [CircleCI Jira integration docs](https://circleci.com/docs/2.0/jira-plugin/)
 
 orbs:
-  jq: circleci/jq@2.0
+  jq: circleci/jq@2.1.0
 
 display:
   home_url: https://circleci.com/docs/2.0/jira-plugin/

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -8,7 +8,7 @@ description: >
   Please see [CircleCI Jira integration docs](https://circleci.com/docs/2.0/jira-plugin/)
 
 orbs:
-  jq: circleci/jq@2.1.0
+  jq: circleci/jq@2.1
 
 display:
   home_url: https://circleci.com/docs/2.0/jira-plugin/


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
`circleci/jq@2.0.2` introduced a fix for the override parameter being ignored. Since this change won't be picked up until another `circleci orb pack` figured it would be best to also bump to 2.1.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Changed `circleci/jq@2.0` to `circleci/jq@2.1`