### PR TITLE
#46 - Always install jq [semver:patch]

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -31,7 +31,8 @@ parameters:
     type: string
 
 steps:
-  - jq/install
+  - jq/install:
+      when: always
 
   - run:
       name: JIRA - Setting Failure Condition

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -8,7 +8,7 @@ description: >
   Please see [CircleCI Jira integration docs](https://circleci.com/docs/2.0/jira-plugin/)
 
 orbs:
-  jq: circleci/jq@2.1
+  jq: circleci/jq@2.2
 
 display:
   home_url: https://circleci.com/docs/2.0/jira-plugin/


### PR DESCRIPTION
### Motivation, issues

See #46

`jira/notify` will always run, regardless of the result of the previous steps, but `jq/install` will only run when the previous steps have been successfu.

### Description

Add `when: always` to the `jq/install`command in `jira/notify`.