### PR TITLE
[semver:minor] Parameter to scan commit body for Issue Tag

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -29,6 +29,10 @@ parameters:
     description: Override the default project key regexp if your project keys follow a different format.
     default: "[A-Z]{2,30}-[0-9]+"
     type: string
+  scan_commit_body:
+    description: Whether or not to scan the Commit Body for the JIRA Issue Tag. Default is false.
+    default: false
+    type: boolean
 
 steps:
   - jq/install:
@@ -99,7 +103,7 @@ steps:
           # must save as ISSUE_KEYS='["CC-4"]'
           fetch https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM} /tmp/job_info.json
           # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [if .branch then .branch else "" end | scan("(<<parameters.issue_regexp>>)")  | . [] ]')
+          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [if .branch then .branch else "" end | scan("(<<parameters.issue_regexp>>)")  | . [] ] + [if <<parameters.scan_commit_body>> then .all_commit_details[].body else "" end | scan("(<<parameters.issue_regexp>>)")   | .[] ]')
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Sometimes multiple JIRA Issues are completed/fixed as part of a single commit.

When we do a commit that contains or fixes multiple Issues, then we give the commit message a single descriptive message and add the JIRA Issue tags to the body of the Commit Message rather than the Subject.

In this case, where the JIRA Issue tags are included in the Commit Body, this Orb will not find pick up those JIRA Issue Tags and fails to update the Issues in JIRA.

### Description

* Added a new optional parameter `scan_commit_body` of type boolean and defaulted to `false` to prevent any unintended issues.
* When scanning for `ISSUE_KEYS`, I have added another optional check that if the `scan_commit_body` parameter is true, then it will include scanning `.all_commit_details[].body` from the json file with the regex.