### PR TITLE
Allow to specific ISSUE_KEYS directly

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -99,10 +99,13 @@ steps:
         }
 
         parse_jira_key_array () {
-          # must save as ISSUE_KEYS='["CC-4"]'
-          fetch https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM} /tmp/job_info.json
-          # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [if .branch then .branch else "" end | scan("(<<parameters.issue_regexp>>)")  | . [] ] + [if <<parameters.scan_commit_body>> then .all_commit_details[].body else "" end | scan("(<<parameters.issue_regexp>>)")   | .[] ]')
+          # Don't override ISSUE_KEYS if it's already set.
+          if [ -z "$ISSUE_KEYS" ]; then
+            # Must save as ISSUE_KEYS='["CC-4"]'
+            fetch https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM} /tmp/job_info.json
+            # See https://jqplay.org/s/TNq7c5ctot
+            ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [if .branch then .branch else "" end | scan("(<<parameters.issue_regexp>>)")  | . [] ] + [if <<parameters.scan_commit_body>> then .all_commit_details[].body else "" end | scan("(<<parameters.issue_regexp>>)")   | .[] ]')
+          fi
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."


### PR DESCRIPTION
### Motivation, issues

This would allow to provide `ISSUE_KEYS` directly in order for user of the orb to change the way they are currently fetched.
We're currently would like to be able to fetch all the commits since the last approved workflow (which requires so many APIs calls, but I digress).

### Description

This only set `ISSUE_KEYS` if it isn't set yet.