### PR TITLE
Allow issue_regexp to define its own capture group

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -101,8 +101,15 @@ steps:
         parse_jira_key_array () {
           # must save as ISSUE_KEYS='["CC-4"]'
           fetch https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM} /tmp/job_info.json
+
+          # If the regex has a capture group, do not wrap it with ()
+          ISSUE_REGEX="<<parameters.issue_regexp>>"
+          if [[ ! "$ISSUE_REGEX" == *[\(\)]* ]]; then
+            ISSUE_REGEX="(<<parameters.issue_regexp>>)"
+          fi
+
           # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [.all_commit_details[].branch | scan("(<<parameters.issue_regexp>>)")   | .[] ] + [if .branch then .branch else "" end | scan("(<<parameters.issue_regexp>>)")  | . [] ] + [if <<parameters.scan_commit_body>> then .all_commit_details[].body else "" end | scan("(<<parameters.issue_regexp>>)")   | .[] ]')
+          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("$ISSUE_REGEX")   | .[] ] + [.all_commit_details[].branch | scan("$ISSUE_REGEX")   | .[] ] + [if .branch then .branch else "" end | scan("$ISSUE_REGEX")  | . [] ] + [if <<parameters.scan_commit_body>> then .all_commit_details[].body else "" end | scan("$ISSUE_REGEX")   | .[] ]')
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -109,7 +109,7 @@ steps:
           fi
 
           # see https://jqplay.org/s/TNq7c5ctot
-          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("$ISSUE_REGEX")   | .[] ] + [.all_commit_details[].branch | scan("$ISSUE_REGEX")   | .[] ] + [if .branch then .branch else "" end | scan("$ISSUE_REGEX")  | . [] ] + [if <<parameters.scan_commit_body>> then .all_commit_details[].body else "" end | scan("$ISSUE_REGEX")   | .[] ]')
+          ISSUE_KEYS=$(cat /tmp/job_info.json | jq '[.all_commit_details[].subject | scan("$ISSUE_REGEX")   | .[] ] + [.all_commit_details[].branch | scan("$ISSUE_REGEX")   | .[] ] + [if .branch then .branch else "" end | scan("$ISSUE_REGEX")  | . [] ] + [if <<parameters.scan_commit_body>> then .all_commit_details[].body else "" end | scan("$ISSUE_REGEX")   | .[] | ascii_upcase ]')
           if [ -z "$ISSUE_KEYS" ]; then
             # No issue keys found.
             echo "No issue keys found. This build does not contain a match for a Jira Issue. Please add your issue ID to the commit message or within the branch name."

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -26,7 +26,7 @@ parameters:
     type: string
     default: ''
   issue_regexp:
-    description: Override the default project key regexp if your project keys follow a different format.
+    description: Override the default project key regexp if your project keys follow a different format.  This regex may optionally define a single capture group using () to select a Jira Issue Key.
     default: "[A-Z]{2,30}-[0-9]+"
     type: string
   scan_commit_body:
@@ -102,7 +102,7 @@ steps:
           # must save as ISSUE_KEYS='["CC-4"]'
           fetch https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM} /tmp/job_info.json
 
-          # If the regex has a capture group, do not wrap it with ()
+          # If the regex has a capture group already, do not wrap it with ()
           ISSUE_REGEX="<<parameters.issue_regexp>>"
           if [[ ! "$ISSUE_REGEX" == *[\(\)]* ]]; then
             ISSUE_REGEX="(<<parameters.issue_regexp>>)"


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The current implementation assumes that `issue_regexp` is its own capture group.  This prevents custom regex that include match conditions that are outside the group.  For example it should be possible to define an issue_regexp like: `.*?\/{0,1}([A-Za-z]{2,3}-[0-9]+)` which will match `eng/FOO-123` but capture `FOO-123` which is a valid JIRA issue tag.

https://jqplay.org/s/ep4KfBKqPb

### Description

Allow users to define a custom capture group in the `issue_regexp`