### PR TITLE
Use project repo name instead of workflow ID as part of environment ID

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -189,7 +189,7 @@ steps:
           --arg pipelineDisplay "#${CIRCLE_PIPELINE_NUMBER} ${CIRCLE_PROJECT_REPONAME}"  \
           --arg deployDisplay "#${CIRCLE_PIPELINE_NUMBER}  ${CIRCLE_PROJECT_REPONAME} - <<parameters.environment>>"  \
           --arg description "${CIRCLE_PROJECT_REPONAME} #${CIRCLE_PIPELINE_NUMBER} ${CIRCLE_JOB} <<parameters.environment>>" \
-          --arg envId "${CIRCLE_WORKFLOW_ID}-<<parameters.environment>>" \
+          --arg envId "${CIRCLE_PROJECT_REPONAME}-<<parameters.environment>>" \
           --arg envName "<<parameters.environment>>" \
           --arg envType "<<parameters.environment_type>>" \
           --argjson issueKeys "${ISSUE_KEYS}" \


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

#88 

### Description

Use project repo name instead of workflow ID